### PR TITLE
Fix run requirements

### DIFF
--- a/lib/novaposhta.rb
+++ b/lib/novaposhta.rb
@@ -3,6 +3,8 @@ require 'active_support'
 require 'novaposhta/version'
 require 'novaposhta/base'
 require 'novaposhta/address'
+require 'uri'
+require 'net/http'
 
 module Novaposhta
   def self.configure


### PR DESCRIPTION
ruby 2.4.2
novaposhta 0.1.0
```
require 'novaposhta'

n = Novaposhta.configure do |config|
  config.url     = 'https://api.novaposhta.ua/v2.0/{format}/'
  config.format  = :json
  config.api_key = '...'
end

p Novaposhta::Address.get_cities
```
Fails with nil response. Debug showed runtime errors on unknown constants 'URI' & 'Novaposhta::Base::Net'